### PR TITLE
fix: use of heap memory from _strtok

### DIFF
--- a/shell.h
+++ b/shell.h
@@ -14,9 +14,8 @@ void _process_input(char *buffer);
 char *_strtok(char *str, char *delim);
 int charcmp(char c, char *cmp);
 int tc(char *str, char *delim);
-void *_memset(char *s, int c, size_t n);
-void free_double(void **ptr, int i);
 int _execute(char *buffer);
 void _process_input( char *buffer);
+int _strcmp(char *s1, char *s2);
 
 #endif

--- a/strutil.c
+++ b/strutil.c
@@ -1,0 +1,61 @@
+#include "shell.h"
+
+/**
+ * _strtok - returns the next token of a string, delimited with a
+ * provided set of characters
+ * @str: provided string
+ * @delim: character set for delimiters
+ *
+ * Return: pointer to the next token (word), if there are no tokens left, the
+ * function will return a null pointer.
+ */
+char *_strtok(char *str, char *delim)
+{
+	int i, len;
+	static char *token;
+	static char *cpy;
+	static int pos;
+
+	if (!str && !cpy)
+		return (NULL);
+
+	if (str && cpy)
+		pos = 0;
+
+	if (!cpy || !token)
+	{
+		cpy = str;
+		pos = 0;
+	}
+
+	for (i = pos, len = 0; cpy[i]; i++)
+	{
+		if (!charcmp(cpy[i], delim))
+			len++;
+		if (!charcmp(cpy[i], delim) && (charcmp(cpy[i + 1], delim) || !cpy[i + 1]))
+		{
+			token = &cpy[(i + 1) - len];
+			token[len] = 0;
+			pos = i + 2;
+			return (token);
+		}
+	}
+	token = NULL;
+	return (token);
+}
+
+/**
+ * _strcmp - compares two strings
+ * @s1: first string
+ * @s2: second string
+ * Return: zero, if the strings are equal. A positive or negative integer if
+ * respectively the first string is alphabetically greater than the second
+ * integer or viceversa.
+ */
+
+int _strcmp(char *s1, char *s2)
+{
+	for (; *s1 != '\0' && *s2 != '\0' && *s2 == *s1; s1++, s2++)
+		;
+	return ((unsigned char)(*s1) - (unsigned char)(*s2));
+}

--- a/util.c
+++ b/util.c
@@ -1,59 +1,6 @@
 #include "shell.h"
 
 /**
- * _strtok - returns the next token of a string, delimited with a
- * provided set of characters
- * @str: provided string
- * @delim: character set for delimiters
- *
- * Return: pointer to the next token (word), if there are no tokens left, the
- * function will return a null pointer.
- */
-char *_strtok(char *str, char *delim)
-{
-	int i, j, k, l, len;
-	static char **arr, *pos;
-	static int n = 1;
-
-	if ((!str && !arr) || !delim)
-		return (NULL);
-	if (pos != NULL)
-	{
-		pos = arr[n++];
-		return (pos);
-	}
-	if (tc(str, delim) == 0)
-		return (NULL);
-	arr = malloc(sizeof(char *) * tc(str, delim) + 8);
-	if (arr == NULL)
-		return (NULL);
-
-	for (i = 0, len = 0, j = 0; str[i]; i++)
-	{
-		if (!charcmp(str[i], delim))
-			len++;
-		if (!charcmp(str[i], delim) && (charcmp(str[i + 1], delim) || !str[i + 1]))
-		{
-			arr[j] = malloc(sizeof(char) * len + 1);
-			if (pos == NULL)
-				pos = arr[j];
-			if (arr[j] == NULL)
-			{
-				free_double((void *)arr, j);
-				return (NULL);
-			}
-			_memset(arr[j], 0, len + 1);
-			for (l = (i + 1) - len, k = 0; l <= i; l++, k++)
-				arr[j][k] = str[l];
-			len = 0;
-			j++;
-		}
-	}
-	arr[j] = NULL;
-	return (pos);
-}
-
-/**
  * tc - Returns the token count of a string, each one separated by a
  * specified delimiter.
  * @str: provided string
@@ -88,37 +35,6 @@ int charcmp(char c, char *cmp)
 		if (c == cmp[i])
 			return (1);
 	return (0);
-}
-
-/**
- * _memset - fills memory n times with a constant byte.
- * @s: pointer to the memory area
- * @c: specified byte
- * @n: amount of bytes to fill
- *
- * Return: pointer to the modified memory
- */
-void *_memset(char *s, int c, size_t n)
-{
-	unsigned int i;
-
-	for (i = 0; i < n; i++)
-		s[i] = c;
-	return (s);
-}
-
-/**
- * free_double - frees a malloc'd double pointer from a specified position
- * @ptr: double pointer
- * @i: position
- *
- * Return: void.
- */
-void free_double(void **ptr, int i)
-{
-	for (; i >= 0; i--)
-		free(ptr[i]);
-	free(ptr);
 }
 
 


### PR DESCRIPTION
Removed usage of heap memory from function _strtok. This function will
not work with read-only strings.